### PR TITLE
Fix compilation issue with Python 3.11.

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -58,7 +58,7 @@ author = u'The Open Virtual Network (OVN) Development Community'
 # The full version, including alpha/beta/rc tags.
 release = None
 filename = "../configure.ac"
-with open(filename, 'rU') as f:
+with open(filename, 'r') as f:
     for line in f:
         if 'AC_INIT' in line:
             # Parse "AC_INIT(openvswitch, 2.7.90, bugs@openvswitch.org)":


### PR DESCRIPTION
Compilation is currently failing with the error:
File "Documentation/conf.py", line 61, in <module>
    with open(filename, 'rU') as f:
         ^^^^^^^^^^^^^^^^^^^^
ValueError: invalid mode: 'rU'

The Porting to Python 3.11 guide [0] says:
open(), io.open(), codecs.open() and fileinput.FileInput no longer accept 'U' ("universal newline") in the file mode. In Python 3, "universal newline" mode is used by default whenever a file is opened in text mode, and the 'U' flag has been deprecated since Python 3.3.

0: https://docs.python.org/3.11/whatsnew/3.11.html#porting-to-python-3-11

Signed-off-by: Frode Nordahl <frode.nordahl@canonical.com>