### PR TITLE
ci: Select OVN branch from PR target branch.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,21 +32,23 @@ jobs:
 
     steps:
     - name: checkout self
-      uses: actions/checkout@v2
-
-    - name: checkout OVS
-      uses: actions/checkout@v2
-      with:
-        repository: 'openvswitch/ovs'
-        path: 'ovs'
-        ref: 'master'
+      uses: actions/checkout@v3
 
     - name: checkout OVN
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: 'ovn-org/ovn'
         path: 'ovn'
-        ref: 'main'
+        # The `base_ref` will only be set for PR and contain the name of the
+        # target branch.  The `ref_name` will be correct for the final push
+        # check after a PR is merged.
+        #
+        # This setup may lead to failures on push to arbitrarily named branches
+        # on a fork, but that is a price worth paying.
+        #
+        # Contributors can raise a draft PR to get accurate results.
+        ref: ${{ github.base_ref || github.ref_name }}
+        submodules: recursive
 
     - name: dependencies
       run: |
@@ -58,7 +60,7 @@ jobs:
     - name: build OVS
       run: |
         set -euxo pipefail
-        pushd ovs
+        pushd ovn/ovs
         ./boot.sh && ./configure || { cat config.log; exit 1; }
         make -j4 || { cat config.log; exit 1; }
         popd
@@ -67,7 +69,7 @@ jobs:
       run: |
         set -euxo pipefail
         pushd ovn
-        ./boot.sh && ./configure --with-ovs-source=../ovs \
+        ./boot.sh && ./configure \
             || { cat config.log; exit 1; }
         popd
 
@@ -75,7 +77,7 @@ jobs:
       run: |
         set -euxo pipefail
         ./boot.sh && ./configure \
-            --with-ovs-source=./ovs \
+            --with-ovs-source=./ovn/ovs \
             --with-ovn-source=./ovn \
             --enable-plug-representor \
             || { cat config.log; exit 1; }
@@ -89,7 +91,7 @@ jobs:
           export CFLAGS="-fno-omit-frame-pointer -fno-common"
           export OVN_CFLAGS="-fsanitize=address"
         fi
-        export DISTCHECK_CONFIGURE_FLAGS="--with-ovs-source=$(realpath ./ovs) --with-ovn-source=$(realpath ./ovn) --enable-plug-representor"
+        export DISTCHECK_CONFIGURE_FLAGS="--with-ovs-source=$(realpath ./ovn/ovs) --with-ovn-source=$(realpath ./ovn) --enable-plug-representor"
         make distcheck -j4 TESTSUITEFLAGS="-j4" RECHECK=yes \
             || { cat */_build/sub/tests/testsuite.log ; exit 1; }
 
@@ -98,7 +100,7 @@ jobs:
         set -euxo pipefail
         pushd ovn
         ./boot.sh && ./configure \
-            --with-ovs-source=$(realpath ../ovs) \
+            --with-ovs-source=$(realpath ./ovs) \
             --with-vif-plug-provider=$(realpath ../) \
             || { cat config.log; exit 1; }
         make -j4 || { cat config.log; exit 1; }
@@ -113,7 +115,7 @@ jobs:
           export CFLAGS="-fno-omit-frame-pointer -fno-common"
           export OVN_CFLAGS="-fsanitize=address"
         fi
-        export DISTCHECK_CONFIGURE_FLAGS="--with-ovs-source=$(realpath ../ovs) --with-plug-provider=$(realpath ../)"
+        export DISTCHECK_CONFIGURE_FLAGS="--with-ovs-source=$(realpath ./ovs) --with-plug-provider=$(realpath ../)"
         make distcheck -j4 TESTSUITEFLAGS="-j4" RECHECK=yes \
             || { cat */_build/sub/tests/testsuite.log ; exit 1; }
         popd

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,13 +10,13 @@ jobs:
       dependencies: |
         automake libtool gcc bc libssl-dev llvm-dev libelf-dev \
         libnuma-dev libpcap-dev ncat libunbound-dev libunwind-dev \
-        libudev-dev
+        libudev-dev python3-scapy
       CC:        ${{ matrix.compiler }}
       TESTSUITE: ${{ matrix.testsuite }}
       ASAN:      ${{ matrix.asan }}
 
     name: linux ${{ join(matrix.*, ' ') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
To avoid manual maintenance of test definitions on stable branches, determine the correct OVN branch name on the basis of PR target branch name.  The OVN-VIF and OVN projects share stable branch names so we can use the value without further processing.

Get OVS from the OVN submodule in the target branch.