### PR TITLE
ci: Install newer version of scapy.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,10 +10,12 @@ on:
 jobs:
   build-linux:
     env:
-      dependencies: |
+      apt-dependencies: |
         automake libtool gcc bc libssl-dev llvm-dev libelf-dev \
         libnuma-dev libpcap-dev ncat libunbound-dev libunwind-dev \
-        libudev-dev python3-scapy
+        libudev-dev python3-pip
+      pip-dependencies: |
+        scapy
       CC:        ${{ matrix.compiler }}
       TESTSUITE: ${{ matrix.testsuite }}
       ASAN:      ${{ matrix.asan }}
@@ -58,7 +60,8 @@ jobs:
         set -euxo pipefail
         sudo apt update
         sudo apt remove -y netcat-openbsd
-        sudo apt -y install ${{ env.dependencies }}
+        sudo apt -y install ${{ env.apt-dependencies }}
+        sudo pip install ${{ env.pip-dependencies }}
 
     - name: build OVS
       run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,6 +2,9 @@ name: Build and Test
 
 on:
   push:
+    branches:
+      - main
+      - 'branch-**'
   pull_request:
 
 jobs:


### PR DESCRIPTION
ovn-org/ovn/b7fe2c8b1b08 makes use of scapy features that are not available in scapy 2.4.4 as shipped with ubuntu-22.04.

This works in the ovn repository because they run the testsuites from purpose built containers instead of directly on the GitHub Actions runner image.

For now let's just install the scapy dependency from pip instead.